### PR TITLE
Initial Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
-language: ruby
-jdk: oraclejdk8
-rvm: 2.2
-before_install: gem install jekyll
-script: ant -buildfile build.xml travis-publish-ig -Dguidename=cqfmeasures -Dspec=http://hl7-fhir.github.io/
+language: node_js
+node_js:
+  - "12"
+services:
+  - docker
+before_install:
+  - sudo chown -R travis ./travis/setup.sh
+  - sudo chmod +x ./travis/setup.sh ./travis/test_measures.sh
+  - ./travis/setup.sh
+script: ./travis/test_measures.sh

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo ">Installing FHIR Bundle Caluclator CLI..."
+npm install -g fhir-bundle-calculator
+
+echo "> Cloning FHIR Generated Patients..."
+git clone https://github.com/projecttacoma/fhir-patient-generator.git

--- a/travis/test_measures.sh
+++ b/travis/test_measures.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd fhir-patient-generator
+
+# Use make commands to test measures and/or
+# compare calculation results against the
+# existing patient sets.


### PR DESCRIPTION
## Summary

This replaces the existing travis config with a new one that sets up the environment necessary to run tests on measures using our tools, fhir-bundle-calculator, and fhir-patient generator. I decided to replace what was there rather than just add to it, because A) their Travis CI doesn't seem to even be running in their repo, B) it was broken when I tried to run it in this repo, and C) there were challenges to getting both ruby and npm installed properly in the same travis config.

For now all this does is prepare the environment for executing tests on measures. In order to get there, I put in a `make` call to fhir-patient-generator and addressed issues by adjusting the travis config until that call succeeded. I have since removed the `make` call.

## To Test

- Check out the Travis job that runs in this PR and verify that it's working as expected.
- In `test_measures.sh`, you could add a `make MEASURE_DIR=<dir>` call, push that change to a separate branch, and then check out the travis job that runs to confirm it works.